### PR TITLE
Allow hrtime to be globally patched

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "coffee-script": "~1.12.2",
     "mocha": "~3.2.0",
     "pre-commit": "^1.2.2",
+    "sinon": "^4.0.1",
+    "sinon-chai": "^2.14.0",
     "typescript": "^2.1.6"
   },
   "optionalDependencies": {},

--- a/src/performance-now.coffee
+++ b/src/performance-now.coffee
@@ -2,9 +2,8 @@ if performance? and performance.now
   module.exports = -> performance.now()
 else if process? and process.hrtime
   module.exports = -> (getNanoSeconds() - nodeLoadTime) / 1e6
-  hrtime = process.hrtime
   getNanoSeconds = ->
-    hr = hrtime()
+    hr = process.hrtime()
     hr[0] * 1e9 + hr[1]
   moduleLoadTime = getNanoSeconds()
   upTime = process.uptime() * 1e9

--- a/test/performance-now.coffee
+++ b/test/performance-now.coffee
@@ -1,5 +1,7 @@
+Sinon = require "sinon"
 chai = require "chai"
 chai.use(require "chai-increasing")
+chai.use( require "sinon-chai")
 {assert,expect} = chai
 Bluebird = require "bluebird"
 
@@ -41,3 +43,13 @@ describe "now", ->
   it "shows that at most 220 ms has passed after a timeout of 200ms", ->
     earlier = now()
     Bluebird.resolve().delay(200).then -> assert.isBelow (now()-earlier), 220
+
+  it "should be able to be patched", ->
+    originalHrTime = global.process.hrtime; # Keep original reference
+    spy = Sinon.spy(global.process, 'hrtime')
+
+    now()
+
+    global.process.hrtime = originalHrTime; # Clean up after test
+
+    expect(spy).to.have.been.calledOnce


### PR DESCRIPTION
This fixes #20.
Replaces #21 (just to make the PR from a fix-branch instead of YR/master